### PR TITLE
Use boolean dtype detection to save time in categorical checks.

### DIFF
--- a/patsy/categorical.py
+++ b/patsy/categorical.py
@@ -158,6 +158,9 @@ class CategoricalSniffer(object):
             # second-guess it.
             self._levels = tuple(data.levels)
             return True
+        elif hasattr(data, 'dtype') and np.issubdtype(data.dtype, np.bool_):
+            self._level_set = set([True, False])
+            return True
         if isinstance(data, _CategoricalBox):
             if data.levels is not None:
                 self._levels = tuple(data.levels)
@@ -193,7 +196,7 @@ def test_CategoricalSniffer():
             else:
                 assert not exp_finish_fast
         assert sniffer.levels_contrast() == (exp_levels, exp_contrast)
-    
+
     if have_pandas_categorical:
         t([], [pandas.Categorical.from_array([1, 2, None])],
           True, (1, 2))
@@ -256,6 +259,9 @@ def categorical_to_int(data, levels, NA_action, origin=None):
         # pandas.Categorical also uses -1 to indicate NA, and we don't try to
         # second-guess its NA detection, so we can just pass it back.
         return data.labels
+    elif hasattr(data, 'dtype') and hasattr(data, 'astype') and \
+            np.issubdtype(data.dtype, np.bool_):
+        return data.astype('int')
     if isinstance(data, _CategoricalBox):
         if data.levels is not None and tuple(data.levels) != levels:
             raise PatsyError("mismatching levels: expected %r, got %r"


### PR DESCRIPTION
I've no idea if these changes are generally useful, but this PR has a couple small changes I'm planning to use internally to save processing time in our usage of patsy.

I work on [synthicity/urbansim](https://github.com/synthicity/urbansim) and our models frequently make use of boolean variables specified in patsy with expressions like `I(year_built < 1940)`. Our problem is that [including categorical variables makes patsy drastically slower](http://nbviewer.ipython.org/gist/fscottfoti/1cec32e70a60e440ebce). We see times approaching a minute to assemble design matrices, and we'd like to avoid that.

Looking at profiling data it's clear that most of the time is spent going through categorical arrays and checking each item individually to see if it is a nan value. In our application the vast majority of our categorical model components will be boolean pandas Series. In that situation it seems like noting the Series dtype should be all that's required to ascertain the categorical levels and lack of nan values. So the changes I've made do exactly that.

As I said, I've no idea if these changes may be generally useful, but I thought our situation might be interesting to the developers. Thanks for a very useful tool!
