### PR TITLE
Create more verbose error message for unicode strings as formulas

### DIFF
--- a/patsy/highlevel.py
+++ b/patsy/highlevel.py
@@ -13,6 +13,7 @@ __all__ = ["dmatrix", "dmatrices",
 #   ModelDesign doesn't work -- need to work with the builder set
 #   want to be able to return either a matrix or a pandas dataframe
 
+import six
 import numpy as np
 from patsy import PatsyError
 from patsy.design_info import DesignMatrix, DesignInfo
@@ -56,6 +57,9 @@ def _try_incr_builders(formula_like, data_iter_maker, eval_env,
                                       data_iter_maker,
                                       NA_action)
     else:
+        # check if formula_like is another string type (which might be unsupported)
+        if isinstance(formula_like, string_types):
+            raise PatsyError("Unsupported string type for formula (e.g., unicode in Python 2.X).")
         return None
 
 def incr_dbuilder(formula_like, data_iter_maker, eval_env=0, NA_action="drop"):


### PR DESCRIPTION
Instead of supporting unicode, give a useful error message when a formula is unicode.