### PR TITLE
Fix for unnecessary prepending default column name. Closes #54.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 ##########################
 
 .coverage
+.idea
 htmlcov/
 .tox
 

--- a/patsy/design_info.py
+++ b/patsy/design_info.py
@@ -281,7 +281,7 @@ class DesignInfo(object):
             and not np.issubdtype(columns.dtype, np.integer)):
             column_names = [str(obj) for obj in columns]
         else:
-            column_names = ["%s%s" % (default_column_prefix, i)
+            column_names = ["%s%s" % (default_column_prefix if str(i).isdigit() else "", i)
                             for i in columns]
         return DesignInfo(column_names)
 


### PR DESCRIPTION
There was unconditional adding prefix, I'd added checking if column name is digit and only therefore prepend default name. It has lead to passing all tests.