### PR TITLE
Pandas 0.15 categorical handling

### DIFF
--- a/patsy/build.py
+++ b/patsy/build.py
@@ -17,7 +17,8 @@ from patsy.categorical import (guess_categorical,
                                CategoricalSniffer,
                                categorical_to_int)
 from patsy.util import (atleast_2d_column_default,
-                        have_pandas, asarray_or_pandas)
+                        have_pandas, asarray_or_pandas,
+                        safe_issubdtype)
 from patsy.design_info import DesignMatrix, DesignInfo
 from patsy.redundancy import pick_contrasts_for_term
 from patsy.desc import ModelDesc
@@ -76,7 +77,7 @@ class _NumFactorEvaluator(object):
                                 % (self.factor.name(), self._expected_columns,
                                    result.shape[1]),
                                 self.factor)
-        if not np.issubdtype(np.asarray(result).dtype, np.number):
+        if not safe_issubdtype(np.asarray(result).dtype, np.number):
             raise PatsyError("when evaluating numeric factor %s, "
                                 "I got non-numeric data of type '%s'"
                                 % (self.factor.name(), result.dtype),

--- a/patsy/categorical.py
+++ b/patsy/categorical.py
@@ -45,7 +45,8 @@ from patsy.util import (SortAnythingKey,
                         safe_is_pandas_categorical,
                         pandas_Categorical_from_codes,
                         pandas_Categorical_categories,
-                        pandas_Categorical_codes)
+                        pandas_Categorical_codes,
+                        safe_issubdtype)
 
 if have_pandas:
     import pandas
@@ -123,7 +124,7 @@ def guess_categorical(data):
     if isinstance(data, _CategoricalBox):
         return True
     data = np.asarray(data)
-    if np.issubdtype(data.dtype, np.number):
+    if safe_issubdtype(data.dtype, np.number):
         return False
     return True
 
@@ -190,7 +191,7 @@ class CategoricalSniffer(object):
                 data = data.data
         # fastpath to avoid doing an item-by-item iteration over boolean
         # arrays, as requested by #44
-        if hasattr(data, "dtype") and np.issubdtype(data.dtype, np.bool_):
+        if hasattr(data, "dtype") and safe_issubdtype(data.dtype, np.bool_):
             self._level_set = set([True, False])
             return True
 
@@ -333,7 +334,7 @@ def categorical_to_int(data, levels, NA_action, origin=None):
 
     # fastpath to avoid doing an item-by-item iteration over boolean arrays,
     # as requested by #44
-    if hasattr(data, "dtype") and np.issubdtype(data.dtype, np.bool_):
+    if hasattr(data, "dtype") and safe_issubdtype(data.dtype, np.bool_):
         if level_to_int[False] == 0 and level_to_int[True] == 1:
             return data.astype(np.int_)
     out = np.empty(len(data), dtype=int)

--- a/patsy/contrasts.py
+++ b/patsy/contrasts.py
@@ -15,7 +15,7 @@ import six
 import numpy as np
 from patsy import PatsyError
 from patsy.compat import triu_indices, tril_indices, diag_indices
-from patsy.util import repr_pretty_delegate, repr_pretty_impl
+from patsy.util import repr_pretty_delegate, repr_pretty_impl, safe_issubdtype
 
 class ContrastMatrix(object):
     """A simple container for a matrix used for coding categorical factors.
@@ -567,7 +567,7 @@ def code_contrast_matrix(intercept, levels, contrast, default=None):
     if isinstance(contrast, ContrastMatrix):
         return contrast
     as_array = np.asarray(contrast)
-    if np.issubdtype(as_array.dtype, np.number):
+    if safe_issubdtype(as_array.dtype, np.number):
         return ContrastMatrix(as_array,
                               _name_levels("custom", range(as_array.shape[1])))
     if intercept:

--- a/patsy/design_info.py
+++ b/patsy/design_info.py
@@ -19,7 +19,7 @@ import numpy as np
 from patsy import PatsyError
 from patsy.util import atleast_2d_column_default
 from patsy.compat import OrderedDict
-from patsy.util import repr_pretty_delegate, repr_pretty_impl
+from patsy.util import repr_pretty_delegate, repr_pretty_impl, safe_issubdtype
 from patsy.constraint import linear_constraint
 
 class DesignInfo(object):
@@ -278,7 +278,7 @@ class DesignInfo(object):
             raise ValueError("design matrix can't have >2 dimensions")
         columns = getattr(arr, "columns", range(arr.shape[1]))
         if (hasattr(columns, "dtype")
-            and not np.issubdtype(columns.dtype, np.integer)):
+            and not safe_issubdtype(columns.dtype, np.integer)):
             column_names = [str(obj) for obj in columns]
         else:
             column_names = ["%s%s" % (default_column_prefix, i)
@@ -527,7 +527,7 @@ class DesignMatrix(np.ndarray):
             return input_array
         self = atleast_2d_column_default(input_array).view(cls)
         # Upcast integer to floating point
-        if np.issubdtype(self.dtype, np.integer):
+        if safe_issubdtype(self.dtype, np.integer):
             self = np.asarray(self, dtype=float).view(cls)
         if self.ndim > 2:
             raise ValueError("DesignMatrix must be 2d")
@@ -539,7 +539,7 @@ class DesignMatrix(np.ndarray):
                              "(got %s, wanted %s)"
                              % (len(design_info.column_names), self.shape[1]))
         self.design_info = design_info
-        if not np.issubdtype(self.dtype, np.floating):
+        if not safe_issubdtype(self.dtype, np.floating):
             raise ValueError("design matrix must be real-valued floating point")
         return self
 

--- a/patsy/state.py
+++ b/patsy/state.py
@@ -27,7 +27,7 @@
 import numpy as np
 from patsy.util import (atleast_2d_column_default,
                         asarray_or_pandas, pandas_friendly_reshape,
-                        wide_dtype_for)
+                        wide_dtype_for, safe_issubdtype)
 from patsy.compat import wraps
 
 # These are made available in the patsy.* namespace
@@ -107,7 +107,7 @@ class Center(object):
         # heterogenous types. And in that case we're going to be munging the
         # types anyway, so copying isn't a big deal.
         x_arr = np.asarray(x)
-        if np.issubdtype(x_arr.dtype, np.integer):
+        if safe_issubdtype(x_arr.dtype, np.integer):
             dt = float
         else:
             dt = x_arr.dtype

--- a/patsy/test_highlevel.py
+++ b/patsy/test_highlevel.py
@@ -19,7 +19,10 @@ from patsy.build import (design_matrix_builders,
                          build_design_matrices,
                          DesignMatrixBuilder)
 from patsy.highlevel import *
-from patsy.util import have_pandas
+from patsy.util import (have_pandas,
+                        have_pandas_categorical,
+                        have_pandas_categorical_dtype,
+                        pandas_Categorical_from_codes)
 from patsy.origin import Origin
 
 if have_pandas:
@@ -702,3 +705,34 @@ def test_0d_data():
             assert np.allclose(build_design_matrices([mat.design_info.builder],
                                                      data_series)[0],
                                expected)
+
+def test_C_and_pandas_categorical():
+    if not have_pandas_categorical:
+        return
+
+    objs = [pandas_Categorical_from_codes([1, 0, 1], ["b", "a"])]
+    if have_pandas_categorical_dtype:
+        objs.append(pandas.Series(objs[0]))
+    for obj in objs:
+        d = {"obj": obj}
+        assert np.allclose(dmatrix("obj", d),
+                           [[1, 1],
+                            [1, 0],
+                            [1, 1]])
+
+        assert np.allclose(dmatrix("C(obj)", d),
+                           [[1, 1],
+                            [1, 0],
+                            [1, 1]])
+
+        assert np.allclose(dmatrix("C(obj, levels=['b', 'a'])", d),
+                           [[1, 1],
+                            [1, 0],
+                            [1, 1]])
+
+        assert np.allclose(dmatrix("C(obj, levels=['a', 'b'])", d),
+                           [[1, 0],
+                            [1, 1],
+                            [1, 0]])
+
+# From https://github.com/pydata/patsy/pull/47#issuecomment-72605624

--- a/patsy/test_highlevel.py
+++ b/patsy/test_highlevel.py
@@ -734,5 +734,3 @@ def test_C_and_pandas_categorical():
                            [[1, 0],
                             [1, 1],
                             [1, 0]])
-
-# From https://github.com/pydata/patsy/pull/47#issuecomment-72605624

--- a/patsy/util.py
+++ b/patsy/util.py
@@ -9,6 +9,15 @@ __all__ = ["atleast_2d_column_default", "uniqueify_list",
            "repr_pretty_delegate", "repr_pretty_impl",
            "SortAnythingKey", "safe_scalar_isnan", "safe_isnan",
            "iterable",
+           "have_pandas",
+           "have_pandas_categorical",
+           "have_pandas_categorical_dtype",
+           "pandas_Categorical_from_codes",
+           "pandas_Categorical_categories",
+           "pandas_Categorical_codes",
+           "safe_is_pandas_categorical_dtype",
+           "safe_is_pandas_categorical",
+           "safe_issubdtype",
            ]
 
 import sys

--- a/patsy/util.py
+++ b/patsy/util.py
@@ -583,6 +583,9 @@ def test_iterable():
 def pandas_Categorical_from_codes(codes, categories):
     assert have_pandas_categorical
 
+    # Old versions of pandas sometimes fail to coerce this to an array and
+    # just return it directly from .labels (?!).
+    codes = np.asarray(codes)
     if hasattr(pandas.Categorical, "from_codes"):
         return pandas.Categorical.from_codes(codes, categories)
     else:

--- a/patsy/util.py
+++ b/patsy/util.py
@@ -598,9 +598,9 @@ def test_pandas_Categorical_from_codes():
 
 # Needed to support pandas < 0.15
 def pandas_Categorical_categories(cat):
-    # In 0.15+, a categorical Series has a .cat attribute which is a
-    # Categorical object, and Categorical objects are what have .categories /
-    # .codes attributes.
+    # In 0.15+, a categorical Series has a .cat attribute which is similar to
+    # a Categorical object, and Categorical objects are what have .categories
+    # and .codes attributes.
     if hasattr(cat, "cat"):
         cat = cat.cat
     if hasattr(cat, "categories"):

--- a/patsy/util.py
+++ b/patsy/util.py
@@ -28,6 +28,9 @@ else:
 # Can drop this guard whenever we drop support for such older versions of
 # pandas.
 have_pandas_categorical = (have_pandas and hasattr(pandas, "Categorical"))
+have_pandas_categorical_dtype = (have_pandas
+                                  and hasattr(pandas.core.common,
+                                              "is_categorical_dtype"))
 
 # Passes through Series and DataFrames, call np.asarray() on everything else
 def asarray_or_pandas(a, copy=False, dtype=None, subok=False):
@@ -550,3 +553,124 @@ def test_iterable():
     assert iterable({"a": 1})
     assert not iterable(1)
     assert not iterable(iterable)
+
+##### Handling Pandas's categorical stuff is horrible and hateful
+
+# Basically they decided that they didn't like how numpy does things, so their
+# categorical stuff is *kinda* like how numpy would do it (e.g. they have a
+# special ".dtype" attribute to mark categorical data), so by default you'll
+# find yourself using the same code paths to handle pandas categorical data
+# and other non-categorical data. BUT, all the idioms for detecting
+# categorical data blow up with errors if you try them with real numpy dtypes,
+# and all numpy's idioms for detecting non-categorical types blow up with
+# errors if you try them with pandas categorical stuff. So basically they have
+# just poisoned all code that touches dtypes; the old numpy stuff is unsafe,
+# and you must use special code like below.
+#
+# Also there are hoops to jump through to handle both the old style
+# (Categorical objects) and new-style (Series with dtype="category").
+
+# Needed to support pandas < 0.15
+def pandas_Categorical_from_codes(codes, categories):
+    assert have_pandas_categorical
+
+    if hasattr(pandas.Categorical, "from_codes"):
+        return pandas.Categorical.from_codes(codes, categories)
+    else:
+        return pandas.Categorical(codes, categories)
+
+def test_pandas_Categorical_from_codes():
+    c = pandas_Categorical_from_codes([1, 1, 0, -1], ["a", "b"])
+    assert np.all(np.asarray(c)[:-1] == ["b", "b", "a"])
+    assert np.isnan(np.asarray(c)[-1])
+
+# Needed to support pandas < 0.15
+def pandas_Categorical_categories(cat):
+    # In 0.15+, a categorical Series has a .cat attribute which is a
+    # Categorical object, and Categorical objects are what have .categories /
+    # .codes attributes.
+    if hasattr(cat, "cat"):
+        cat = cat.cat
+    if hasattr(cat, "categories"):
+        return cat.categories
+    else:
+        return cat.levels
+
+# Needed to support pandas < 0.15
+def pandas_Categorical_codes(cat):
+    # In 0.15+, a categorical Series has a .cat attribute which is a
+    # Categorical object, and Categorical objects are what have .categories /
+    # .codes attributes.
+    if hasattr(cat, "cat"):
+        cat = cat.cat
+    if hasattr(cat, "codes"):
+        return cat.codes
+    else:
+        return cat.labels
+
+def test_pandas_Categorical_accessors():
+    c = pandas_Categorical_from_codes([1, 1, 0, -1], ["a", "b"])
+    assert np.all(pandas_Categorical_categories(c) == ["a", "b"])
+    assert np.all(pandas_Categorical_codes(c) == [1, 1, 0, -1])
+
+    if have_pandas_categorical_dtype:
+        s = pandas.Series(c)
+        assert np.all(pandas_Categorical_categories(s) == ["a", "b"])
+        assert np.all(pandas_Categorical_codes(s) == [1, 1, 0, -1])
+
+# Needed to support pandas >= 0.15 (!)
+def safe_is_pandas_categorical_dtype(dt):
+    if not have_pandas_categorical_dtype:
+        return False
+    # WTF this incredibly crucial function is not even publically exported.
+    # Also if you read its source it uses a bare except: block which is broken
+    # by definition, but oh well there is not much I can do about this.
+    return pandas.core.common.is_categorical_dtype(dt)
+
+# Needed to support pandas >= 0.15 (!)
+def safe_is_pandas_categorical(data):
+    if not have_pandas_categorical:
+        return False
+    if isinstance(data, pandas.Categorical):
+        return True
+    if hasattr(data, "dtype"):
+        return safe_is_pandas_categorical_dtype(data.dtype)
+    return False
+
+def test_safe_is_pandas_categorical():
+    assert not safe_is_pandas_categorical(np.arange(10))
+
+    if have_pandas_categorical:
+        c_obj = pandas.Categorical.from_array(["a", "b"])
+        assert safe_is_pandas_categorical(c_obj)
+
+    if have_pandas_categorical_dtype:
+        s_obj = pandas.Series(["a", "b"], dtype="category")
+        assert safe_is_pandas_categorical(s_obj)
+
+# Needed to support pandas >= 0.15 (!)
+# Calling np.issubdtype on a pandas categorical will blow up -- the officially
+# recommended solution is to replace every piece of code like
+#   np.issubdtype(foo.dtype, bool)
+# with code like
+#   isinstance(foo.dtype, np.dtype) and np.issubdtype(foo.dtype, bool)
+# or
+#   not pandas.is_categorical_dtype(foo.dtype) and issubdtype(foo.dtype, bool)
+# We do the latter (with extra hoops) because the isinstance check is not
+# safe. See
+#   https://github.com/pydata/pandas/issues/9581
+#   https://github.com/pydata/pandas/issues/9581#issuecomment-77099564
+def safe_issubdtype(dt1, dt2):
+    if safe_is_pandas_categorical_dtype(dt1):
+        return False
+    return np.issubdtype(dt1, dt2)
+
+def test_safe_issubdtype():
+    assert safe_issubdtype(int, np.integer)
+    assert safe_issubdtype(np.dtype(float), np.floating)
+    assert not safe_issubdtype(int, np.floating)
+    assert not safe_issubdtype(np.dtype(float), np.integer)
+
+    if have_pandas_categorical_dtype:
+        bad_dtype = pandas.Series(["a", "b"], dtype="category")
+        assert not safe_issubdtype(bad_dtype, np.integer)

--- a/patsy/util.py
+++ b/patsy/util.py
@@ -270,10 +270,10 @@ else: # pragma: no cover
 
 def wide_dtype_for(arr):
     arr = np.asarray(arr)
-    if (np.issubdtype(arr.dtype, np.integer)
-        or np.issubdtype(arr.dtype, np.floating)):
+    if (safe_issubdtype(arr.dtype, np.integer)
+        or safe_issubdtype(arr.dtype, np.floating)):
         return widest_float
-    elif np.issubdtype(arr.dtype, np.complexfloating):
+    elif safe_issubdtype(arr.dtype, np.complexfloating):
         return widest_complex
     raise ValueError("cannot widen a non-numeric type %r" % (arr.dtype,))
 


### PR DESCRIPTION
Okay, here's my attempt to work around the changes in categorical handling in pandas 0.15.

@JanSchulz: I would very much appreciate a review, since this is heavily based on your patch in #47 (plus some refactoring to try and fix a few more issues). The individual commits are logical chunks, so it might be easier to read that way then as one giant patch.

I'd also really appreciate if you could write down a self-contained test that triggers the issue in pydata/pandas#9581, or at least enough of an example to let me trigger it? I'm pretty sure I fixed it, but I'm not sure how to write a test case for it...

@kousu: I don't fully understand the issues you described in https://github.com/pydata/patsy/pull/47#issuecomment-72605624 , so I'm not sure whether I've fixed them or not :-). (They did make me squint harder at the interaction between `C()` and pandas categoricals, which helped me find a bug! But I don't think it was your bug.) If you happen to have the chance, I'd be interested in (a) whether installing this branch fixes your problems, (b) whether you could write a small self-contained test (i.e., avoiding `read_csv` and just calling `patsy.dmatrix` or `patsy.dmatrices` instead of using statsmodels) that triggers the issues you were seeing, so either so I can debug further (if it's not fixed), or add a test case (if it is fixed, so it will stay fixed).