### PR TITLE
Capture vars not env

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -3,6 +3,19 @@ Changes
 
 .. currentmodule:: patsy
 
+v0.4.0
+------
+
+* Formulas (more precisely, :class:`EvalFactor` objects) now only
+  keep a reference to the variables required from their environment
+  instead of the whole environment when the formula was defined.
+
+* Incompatible change: :class:`EvalFactor` does not take an
+  ``eval_env`` argument anymore.
+
+* Incompatible change: the :func:`design_matrix_builders` function now
+  requires an ``eval_env`` as an additional argument.
+
 v0.3.0
 ------
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -13,7 +13,8 @@ v0.4.0
 * Incompatible change: :class:`EvalFactor` does not take an
   ``eval_env`` argument anymore.
 
-* Incompatible change: the :func:`design_matrix_builders` function now
+* Incompatible change: the :func:`design_matrix_builders` function and
+  the :meth:`EvalFactor.memorize_passes_needed` method now
   requires an ``eval_env`` as an additional argument.
 
 v0.3.0

--- a/doc/expert-model-specification.rst
+++ b/doc/expert-model-specification.rst
@@ -78,12 +78,11 @@ things are.)
    from patsy import (ModelDesc, EvalEnvironment, Term, EvalFactor,
                       LookupFactor, demo_data, dmatrix)
    data = demo_data("a", "x")
-   env = EvalEnvironment.capture()
 
    # LookupFactor takes a dictionary key:
    a_lookup = LookupFactor("a")
    # EvalFactor takes arbitrary Python code:
-   x_transform = EvalFactor("np.log(x ** 2)", env)
+   x_transform = EvalFactor("np.log(x ** 2)")
    # First argument is empty list for dmatrix; we would need to put
    # something there if we were calling dmatrices.
    desc = ModelDesc([],
@@ -157,7 +156,7 @@ The full interface looks like this:
        :term:`hashable`. These methods will determine which factors
        Patsy considers equal for purposes of redundancy elimination.
 
-    .. method:: memorize_passes_needed(state)
+    .. method:: memorize_passes_needed(state, eval_env)
 
        Return the number of passes through the data that this factor
        will need in order to set up any :ref:`stateful-transforms`.
@@ -170,6 +169,9 @@ The full interface looks like this:
        builder machinery, and that we can do whatever we like with. It
        will be passed back in to all memorization and evaluation
        methods.
+
+       `eval_env` is an :class:`EvalEnvironment` object, describing
+       the Python environment where the factor is being evaluated.
 
     .. method:: memorize_chunk(state, which_pass, data)
 

--- a/doc/formulas.rst
+++ b/doc/formulas.rst
@@ -58,13 +58,12 @@ To make this more concrete, here's how you could manually construct
 the same objects that Patsy will construct if given the above
 formula::
 
-  from patsy import EvalEnvironment, ModelDesc
-  env = EvalEnvironment.capture()
-  ModelDesc([Term([EvalFactor("y", env)])],
+  from patsy import ModelDesc
+  ModelDesc([Term([EvalFactor("y")])],
             [Term([]),
-             Term([EvalFactor("a", env)]),
-             Term([EvalFactor("a", env), EvalFactor("b", env)]),
-             Term([EvalFactor("np.log(x)", env)])])
+             Term([EvalFactor("a")]),
+             Term([EvalFactor("a"), EvalFactor("b")]),
+             Term([EvalFactor("np.log(x)")])])
 
 Compare to what you get from parsing the above formula::
 

--- a/patsy/build.py
+++ b/patsy/build.py
@@ -614,7 +614,7 @@ def _make_term_column_builders(terms,
             term_to_column_builders[term] = column_builders
     return new_term_order, term_to_column_builders
 
-def design_matrix_builders(termlists, data_iter_maker, eval_env=0, NA_action="drop"):
+def design_matrix_builders(termlists, data_iter_maker, eval_env, NA_action="drop"):
     """Construct several :class:`DesignMatrixBuilders` from termlists.
 
     This is one of Patsy's fundamental functions. This function and

--- a/patsy/build.py
+++ b/patsy/build.py
@@ -659,7 +659,7 @@ def design_matrix_builders(termlists, data_iter_maker, eval_env, NA_action="drop
     # not as a keyword argument a nice error message here, instead of a
     # more obscure backtrace later on.
     if not isinstance(eval_env, six.integer_types + (EvalEnvironment,)):
-        raise TypeError("Parameter 'eval_env' must be either an integer or an instance" +
+        raise TypeError("Parameter 'eval_env' must be either an integer or an instance "
                         "of patsy.EvalEnvironment.")
     eval_env = EvalEnvironment.capture(eval_env, reference=1)
     if isinstance(NA_action, str):

--- a/patsy/build.py
+++ b/patsy/build.py
@@ -653,6 +653,11 @@ def design_matrix_builders(termlists, data_iter_maker, eval_env=0, NA_action="dr
     .. versionadded:: 0.4.0
        The ``eval_env`` argument.
     """
+    # Check type of eval_env to help people migrating to 0.4.0. Third
+    # argument used to be NA_action (a string). Having the check for
+    # eval_env's type gives people migrating to 0.4.0 who used NA_action
+    # not as a keyword argument a nice error message here, instead of a
+    # more obscure backtrace later on.
     if not isinstance(eval_env, six.integer_types + (EvalEnvironment,)):
         raise TypeError("Parameter 'eval_env' must be either an integer or an instance" +
                         "of patsy.EvalEnvironment.")

--- a/patsy/desc.py
+++ b/patsy/desc.py
@@ -584,7 +584,7 @@ _eval_error_tests = [
     "a + <-a**2>",
 ]
 
-def _assert_terms_match(terms, expected_intercept, expecteds, eval_env): # pragma: no cover
+def _assert_terms_match(terms, expected_intercept, expecteds): # pragma: no cover
     if expected_intercept:
         expecteds = [()] + expecteds
     assert len(terms) == len(expecteds)
@@ -607,11 +607,9 @@ def _do_eval_formula_tests(tests): # pragma: no cover
         print(model_desc)
         lhs_intercept, lhs_termlist, rhs_intercept, rhs_termlist = result
         _assert_terms_match(model_desc.lhs_termlist,
-                            lhs_intercept, lhs_termlist,
-                            eval_env)
+                            lhs_intercept, lhs_termlist)
         _assert_terms_match(model_desc.rhs_termlist,
-                            rhs_intercept, rhs_termlist,
-                            eval_env)
+                            rhs_intercept, rhs_termlist)
 
 def test_eval_formula():
     _do_eval_formula_tests(_eval_tests)

--- a/patsy/desc.py
+++ b/patsy/desc.py
@@ -191,8 +191,8 @@ def test_ModelDesc_from_formula():
     for input in ("y ~ x", parse_formula("y ~ x")):
         eval_env = EvalEnvironment.capture(0)
         md = ModelDesc.from_formula(input, eval_env)
-        assert md.lhs_termlist == [Term([EvalFactor("y", eval_env)]),]
-        assert md.rhs_termlist == [INTERCEPT, Term([EvalFactor("x", eval_env)])]
+        assert md.lhs_termlist == [Term([EvalFactor("y")]),]
+        assert md.rhs_termlist == [INTERCEPT, Term([EvalFactor("x")])]
 
 class IntermediateExpr(object):
     "This class holds an intermediate result while we're evaluating a tree."
@@ -356,8 +356,7 @@ def _eval_number(evaluator, tree):
                         "only allowed with **", tree)
 
 def _eval_python_expr(evaluator, tree):
-    factor = EvalFactor(tree.token.extra, evaluator._factor_eval_env,
-                        origin=tree.origin)
+    factor = EvalFactor(tree.token.extra, origin=tree.origin)
     return IntermediateExpr(False, None, False, [Term([factor])])
 
 class Evaluator(object):
@@ -593,8 +592,7 @@ def _assert_terms_match(terms, expected_intercept, expecteds, eval_env): # pragm
         if isinstance(term, Term):
             if isinstance(expected, str):
                 expected = (expected,)
-            assert term.factors == tuple([EvalFactor(s, eval_env)
-                                          for s in expected])
+            assert term.factors == tuple([EvalFactor(s) for s in expected])
         else:
             assert term == expected
 

--- a/patsy/eval.py
+++ b/patsy/eval.py
@@ -90,13 +90,16 @@ def ast_names(code):
 
     :arg code: A string containing a Python expression.
     """
+    # Syntax that allows new name bindings to be introduced is tricky to
+    # handle here, so we just refuse to do so.
     disallowed_ast_nodes = (ast.Lambda, ast.ListComp, ast.GeneratorExp)
     if sys.version_info >= (2, 7):
         disallowed_ast_nodes += (ast.DictComp, ast.SetComp)
 
     for node in ast.walk(ast.parse(code)):
         if isinstance(node, disallowed_ast_nodes):
-            raise PatsyError("Lambda, list/dict/set comprehension, generator expression in patsy formula not currently supported.")
+            raise PatsyError("Lambda, list/dict/set comprehension, generator "
+                             "expression in patsy formula not currently supported.")
         if isinstance(node, ast.Name):
             yield node.id
 
@@ -534,7 +537,10 @@ class EvalFactor(object):
 
     def memorize_chunk(self, state, which_pass, data):
         for obj_name in state["pass_bins"][which_pass]:
-            self._eval(state["memorize_code"][obj_name], state["eval_env"],state, data)
+            self._eval(state["memorize_code"][obj_name],
+                       state["eval_env"],
+                       state,
+                       data)
 
     def memorize_finish(self, state, which_pass):
         for obj_name in state["pass_bins"][which_pass]:

--- a/patsy/eval.py
+++ b/patsy/eval.py
@@ -17,6 +17,7 @@ import __future__
 import inspect
 import tokenize
 import six
+import ast
 from patsy import PatsyError
 from patsy.util import PushbackAdapter
 from patsy.tokens import (pretty_untokenize, normalize_token_spacing,
@@ -81,6 +82,23 @@ def test_VarLookupDict():
     ds["a"] = 10
     assert ds["a"] == 10
     assert d1["a"] == 1
+
+def ast_names(code):
+    """Iterator that yields all the (ast) names in a Python expression.
+
+    :arg code: A string containing a Python expression.
+    """
+    for node in ast.walk(ast.parse(code)):
+        if isinstance(node, ast.Name):
+            yield node.id
+
+def test_ast_names():
+    test_data = [('np.log(x)', ['np', 'x']),
+                 ('x', ['x']),
+                 ('center(x + 1)', ['center', 'x']),
+                  ('dt.date.dt.month', ['dt'])]
+    for code, expected in test_data:
+        assert set(ast_names(code)) == set(expected)
 
 class EvalEnvironment(object):
     """Represents a Python execution environment.

--- a/patsy/eval.py
+++ b/patsy/eval.py
@@ -82,6 +82,8 @@ def test_VarLookupDict():
     ds["a"] = 10
     assert ds["a"] == 10
     assert d1["a"] == 1
+    assert ds.get("c") is None
+    assert isinstance(repr(ds), six.string_types)
 
 def ast_names(code):
     """Iterator that yields all the (ast) names in a Python expression.

--- a/patsy/eval.py
+++ b/patsy/eval.py
@@ -582,7 +582,7 @@ def test_EvalFactor_memorize_passes_needed():
     for name in ["foo", "bar", "quux"]:
         assert state["eval_env"].namespace[name] is locals()[name]
     for name in ["w", "x", "y", "z", "e", "state"]:
-        assert state["eval_env"].namespace.get(name) is None
+        assert name not in state["eval_env"].namespace
     assert state["transforms"] == {"_patsy_stobj0__foo__": "FOO-OBJ",
                                    "_patsy_stobj1__bar__": "BAR-OBJ",
                                    "_patsy_stobj2__foo__": "FOO-OBJ",
@@ -638,7 +638,7 @@ def test_EvalFactor_end_to_end():
     assert passes == 2
     assert state["eval_env"].namespace["foo"] is foo
     for name in ["x", "y", "e", "state"]:
-        assert state["eval_env"].namespace.get(name) is None
+        assert name not in state["eval_env"].namespace
     import numpy as np
     e.memorize_chunk(state, 0,
                      {"x": np.array([1, 2]),

--- a/patsy/highlevel.py
+++ b/patsy/highlevel.py
@@ -33,7 +33,7 @@ if have_pandas:
 def _try_incr_builders(formula_like, data_iter_maker, eval_env,
                        NA_action):
     if isinstance(formula_like, DesignMatrixBuilder):
-        return (design_matrix_builders([[]], data_iter_maker, NA_action)[0],
+        return (design_matrix_builders([[]], data_iter_maker, eval_env, NA_action)[0],
                 formula_like)
     if (isinstance(formula_like, tuple)
         and len(formula_like) == 2
@@ -53,7 +53,7 @@ def _try_incr_builders(formula_like, data_iter_maker, eval_env,
     if isinstance(formula_like, ModelDesc):
         return design_matrix_builders([formula_like.lhs_termlist,
                                        formula_like.rhs_termlist],
-                                      data_iter_maker,
+                                      data_iter_maker, eval_env,
                                       NA_action)
     else:
         return None

--- a/patsy/highlevel.py
+++ b/patsy/highlevel.py
@@ -53,7 +53,8 @@ def _try_incr_builders(formula_like, data_iter_maker, eval_env,
     if isinstance(formula_like, ModelDesc):
         return design_matrix_builders([formula_like.lhs_termlist,
                                        formula_like.rhs_termlist],
-                                      data_iter_maker, eval_env,
+                                      data_iter_maker,
+                                      eval_env,
                                       NA_action)
     else:
         return None

--- a/patsy/test_build.py
+++ b/patsy/test_build.py
@@ -559,6 +559,12 @@ def test_same_factor_in_two_matrices():
     check_design_matrix(m2, 2, t2, column_names=["x:a[a1]", "x:a[a2]"])
     assert np.allclose(m2, [[1, 0], [0, 2], [3, 0]])
 
+def test_eval_env_type_builder():
+    data = {"x": [1, 2, 3]}
+    def iter_maker():
+        yield data
+    assert_raises(TypeError, design_matrix_builders, [make_termlist("x")], iter_maker, "foo")
+
 def test_categorical():
     data_strings = {"a": ["a1", "a2", "a1"]}
     data_categ = {"a": C(["a2", "a1", "a2"])}

--- a/patsy/test_build.py
+++ b/patsy/test_build.py
@@ -63,7 +63,7 @@ def make_matrix(data, expected_rank, entries, column_names=None):
     termlist = make_termlist(*entries)
     def iter_maker():
         yield data
-    builders = design_matrix_builders([termlist], iter_maker)
+    builders = design_matrix_builders([termlist], iter_maker, eval_env=0)
     matrices = build_design_matrices(builders, data)
     matrix = matrices[0]
     assert (builders[0].design_info.term_slices
@@ -232,7 +232,7 @@ def test_build_design_matrices_dtype():
     data = {"x": [1, 2, 3]}
     def iter_maker():
         yield data
-    builder = design_matrix_builders([make_termlist("x")], iter_maker)[0]
+    builder = design_matrix_builders([make_termlist("x")], iter_maker, 0)[0]
 
     mat = build_design_matrices([builder], data)[0]
     assert mat.dtype == np.dtype(np.float64)
@@ -248,7 +248,7 @@ def test_return_type():
     data = {"x": [1, 2, 3]}
     def iter_maker():
         yield data
-    builder = design_matrix_builders([make_termlist("x")], iter_maker)[0]
+    builder = design_matrix_builders([make_termlist("x")], iter_maker, 0)[0]
     
     # Check explicitly passing return_type="matrix" works
     mat = build_design_matrices([builder], data, return_type="matrix")[0]
@@ -263,7 +263,7 @@ def test_NA_action():
     initial_data = {"x": [1, 2, 3], "c": ["c1", "c2", "c1"]}
     def iter_maker():
         yield initial_data
-    builder = design_matrix_builders([make_termlist("x", "c")], iter_maker)[0]
+    builder = design_matrix_builders([make_termlist("x", "c")], iter_maker, 0)[0]
 
     # By default drops rows containing either NaN or None
     mat = build_design_matrices([builder],
@@ -310,7 +310,7 @@ def test_NA_drop_preserves_levels():
     data = {"x": [1.0, np.nan, 3.0], "c": ["c1", "c2", "c3"]}
     def iter_maker():
         yield data
-    builder = design_matrix_builders([make_termlist("x", "c")], iter_maker)[0]
+    builder = design_matrix_builders([make_termlist("x", "c")], iter_maker, 0)[0]
 
     assert builder.design_info.column_names == ["c[c1]", "c[c2]", "c[c3]", "x"]
 
@@ -330,14 +330,17 @@ def test_return_type_pandas():
                             index=[10, 20, 30])
     def iter_maker():
         yield data
-    int_builder, = design_matrix_builders([make_termlist([])], iter_maker)
+    int_builder, = design_matrix_builders([make_termlist([])], iter_maker, 0)
     (y_builder, x_builder) = design_matrix_builders([make_termlist("y"),
                                                      make_termlist("x")],
-                                                    iter_maker)
+                                                    iter_maker,
+                                                    eval_env=0)
     (x_a_builder,) = design_matrix_builders([make_termlist("x", "a")],
-                                            iter_maker)
+                                            iter_maker,
+                                            eval_env=0)
     (x_y_builder,) = design_matrix_builders([make_termlist("x", "y")],
-                                            iter_maker)
+                                            iter_maker,
+                                            eval_env=0)
     # Index compatibility is always checked for pandas input, regardless of
     # whether we're producing pandas output
     assert_raises(PatsyError,
@@ -471,7 +474,7 @@ def test_data_mismatch():
             yield {"x": data1}
             yield {"x": data2}
         try:
-            builders = design_matrix_builders([termlist], iter_maker)
+            builders = design_matrix_builders([termlist], iter_maker, 0)
             build_design_matrices(builders, {"x": data1})
             build_design_matrices(builders, {"x": data2})
         except PatsyError:
@@ -481,7 +484,7 @@ def test_data_mismatch():
     def t_setup_predict(data1, data2):
         def iter_maker():
             yield {"x": data1}
-        builders = design_matrix_builders([termlist], iter_maker)
+        builders = design_matrix_builders([termlist], iter_maker, 0)
         assert_raises(PatsyError,
                       build_design_matrices, builders, {"x": data2})
     for (a, b) in test_cases_twoway:
@@ -510,11 +513,12 @@ def test_data_independent_builder():
     # - the index argument is not given
     # - the data is not a DataFrame
     # - there are no other matrices
-    null_builder = design_matrix_builders([make_termlist()], iter_maker)[0]
+    null_builder = design_matrix_builders([make_termlist()], iter_maker, 0)[0]
     assert_raises(PatsyError, build_design_matrices, [null_builder], data)
 
     intercept_builder = design_matrix_builders([make_termlist([])],
-                                               iter_maker)[0]
+                                               iter_maker,
+                                               eval_env=0)[0]
     assert_raises(PatsyError, build_design_matrices, [intercept_builder], data)
 
     assert_raises(PatsyError,
@@ -534,13 +538,15 @@ def test_data_independent_builder():
     x_termlist = make_termlist(["x"])
 
     builders = design_matrix_builders([x_termlist, make_termlist()],
-                                      iter_maker)
+                                      iter_maker,
+                                      eval_env=0)
     x_m, null_m = build_design_matrices(builders, data)
     assert np.allclose(x_m, [[1], [2], [3]])
     assert null_m.shape == (3, 0)
 
     builders = design_matrix_builders([x_termlist, make_termlist([])],
-                                      iter_maker)
+                                      iter_maker,
+                                      eval_env=0)
     x_m, null_m = build_design_matrices(builders, data)
     x_m, intercept_m = build_design_matrices(builders, data)
     assert np.allclose(x_m, [[1], [2], [3]])
@@ -552,7 +558,7 @@ def test_same_factor_in_two_matrices():
         yield data
     t1 = make_termlist(["x"])
     t2 = make_termlist(["x", "a"])
-    builders = design_matrix_builders([t1, t2], iter_maker)
+    builders = design_matrix_builders([t1, t2], iter_maker, eval_env=0)
     m1, m2 = build_design_matrices(builders, data)
     check_design_matrix(m1, 1, t1, column_names=["x"])
     assert np.allclose(m1, [[1], [2], [3]])
@@ -576,7 +582,8 @@ def test_categorical():
         def iter_maker():
             yield data1
         builders = design_matrix_builders([make_termlist(["a"])],
-                                          iter_maker)
+                                          iter_maker,
+                                          eval_env=0)
         build_design_matrices(builders, data2)
     for data1 in datas:
         for data2 in datas:
@@ -672,7 +679,7 @@ def test_DesignMatrixBuilder_subset():
     all_terms = make_termlist("x", "y", "z")
     def iter_maker():
         yield all_data
-    all_builder = design_matrix_builders([all_terms], iter_maker)[0]
+    all_builder = design_matrix_builders([all_terms], iter_maker, 0)[0]
     full_matrix = build_design_matrices([all_builder], all_data)[0]
 
     def t(which_terms, variables, columns):

--- a/patsy/test_highlevel.py
+++ b/patsy/test_highlevel.py
@@ -703,3 +703,12 @@ def test_0d_data():
             assert np.allclose(build_design_matrices([mat.design_info.builder],
                                                      data_series)[0],
                                expected)
+
+def test_env_not_saved_in_builder():
+    x_in_env = [1, 2, 3]
+    design_matrix = dmatrix("x_in_env", {})
+
+    x_in_env = [10, 20, 30]
+    design_matrix2 = dmatrix(design_matrix.design_info.builder, {})
+
+    assert np.allclose(design_matrix, design_matrix2)

--- a/patsy/test_highlevel.py
+++ b/patsy/test_highlevel.py
@@ -279,7 +279,8 @@ def test_formula_likes():
                  [Term([]), Term([LookupFactor("x")])],
                  )
     builders = design_matrix_builders(termlists,
-                                      lambda: iter([{"x": [1, 2, 3]}]))
+                                      lambda: iter([{"x": [1, 2, 3]}]),
+                                      eval_env=0)
     # twople but with no LHS
     t((builders[0], builders[2]), {"x": [10, 20, 30]}, 0,
       True,

--- a/patsy/user_util.py
+++ b/patsy/user_util.py
@@ -199,10 +199,10 @@ class LookupFactor(object):
         return hash((LookupFactor, self._varname,
                      self._force_categorical, self._contrast, self._levels))
 
-    def memorize_passes_needed(self, state):
+    def memorize_passes_needed(self, state, eval_env):
         return 0
 
-    def memorize_chunk(self, state, which_pass, env): # pragma: no cover
+    def memorize_chunk(self, state, which_pass, data): # pragma: no cover
         assert False
 
     def memorize_finish(self, state, which_pass): # pragma: no cover


### PR DESCRIPTION
This is the current state of my work  to capture only the required variables for patsy formulas instead of the whole environment.

Current status: 
- [x] Add new methods to EvalEnvironment to create a environment that contains only a subset of variables.
- [x] Refactor EvalFactor (and update all users) to move the eval_env parameter out of the its initializer method and into the state.
- [x] Additions to doc/changes.rst (esp. to document the incompatible changes!)
- [x] Do a quick pass through the docs to catch anything that's now out-of-date.
- [x] Add "end-to-end" test or two -- something that tests the user-visible behaviour directly, like running a formula through dmatrix, then modifying the original environment, and then running some more data through the same builder (like we were doing predictions) and checking that it is unaffected by our changes to the env. (test_highlevel.py is where the other tests like this go.)
- [x] Create right subset EvalEnvironment and stash it into the state dict for EvalFactor.
- [x] ~~Figure out what the right thing to do is when variables are shadowed between the EvalFactor's environment and the data.~~ (Can be done together with #13 instead. Not a blocker for this.)

When this is complete, it will fix bug #25.