### PR TITLE
[doc] How to access the EvalEnviroment namespace

### DIFF
--- a/patsy/eval.py
+++ b/patsy/eval.py
@@ -186,11 +186,11 @@ class EvalEnvironment(object):
 
           x = 1
           this_env = EvalEnvironment.capture()
-          assert this_env["x"] == 1
+          assert this_env.namespace["x"] == 1
           def child_func():
               return EvalEnvironment.capture(1)
           this_env_from_child = child_func()
-          assert this_env_from_child["x"] == 1
+          assert this_env_from_child.namespace["x"] == 1
 
         Example::
 


### PR DESCRIPTION
Fixes the example as show [here](http://patsy.readthedocs.org/en/latest/API-reference.html#patsy.EvalEnvironment.capture).
