### PR TITLE
xarray support for categorical data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_install:
   - conda info -a
   - conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION numpy scipy coverage nose pip
   - source activate testenv
-  - if [ "$PANDAS_VERSION_STR" != "NONE" ]; then conda install pandas${PANDAS_VERSION_STR}; fi
+  - if [ "$PANDAS_VERSION_STR" != "NONE" ]; then conda install pandas${PANDAS_VERSION_STR} xarray; fi
 install:
   - python setup.py sdist
   - pip install dist/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ matrix:
       env: PANDAS_VERSION_STR="=0.14.0 libgfortran=1.0"
     # 0.18.0 has is_categorical_dtype in a different place than 0.19.0+
     - python: 3.4
-      env: PANDAS_VERSION_STR="=0.18.0"
+      env: PANDAS_VERSION_STR="=0.18.0" XARRAY_VERSION_STR=">=0.7.0"
     - python: 2.7
-      env: PANDAS_VERSION_STR="=0.18.0"
+      env: PANDAS_VERSION_STR="=0.18.0" XARRAY_VERSION_STR=">=0.7.0"
     # make sure it works without pandas
     - python: 3.5
       env: PANDAS_VERSION_STR="NONE"
@@ -41,7 +41,8 @@ before_install:
   - conda info -a
   - conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION numpy scipy coverage nose pip
   - source activate testenv
-  - if [ "$PANDAS_VERSION_STR" != "NONE" ]; then conda install pandas${PANDAS_VERSION_STR} xarray; fi
+  - if [ "$PANDAS_VERSION_STR" != "NONE" ]; then conda install pandas${PANDAS_VERSION_STR}; fi
+  - if [ -n "$XARRAY_VERSION_STR" ]; then conda install xarray${XARRAY_VERSION_STR}; fi
 install:
   - python setup.py sdist
   - pip install dist/*

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -236,6 +236,8 @@ intersphinx_mapping = {"python": ("http://docs.python.org", None),
                                  None),
                        "pandas": ('http://pandas.pydata.org/pandas-docs/stable/',
                                   None),
+                       "xarray": ('http://http://xarray.pydata.org/en/stable/',
+                                  None),
                        }
 
 autodoc_member_order = "source"

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -24,8 +24,9 @@ variables:
 Of course Patsy doesn't much care what sort of object you store
 your data in, so long as it can be indexed like a Python dictionary,
 ``data[varname]``. You may prefer to store your data in a `pandas
-<http://pandas.pydata.org>`_ DataFrame, or a numpy
-record array... whatever makes you happy.
+<http://pandas.pydata.org>`_ DataFrame, an
+`xarray <http://xarray.pydata.org>`_ Dataset (using variables that have
+1 or 2 dimensions), or a numpy record array... whatever makes you happy.
 
 Now, let's generate design matrices suitable for regressing ``y`` onto
 ``x1`` and ``x2``.

--- a/patsy/categorical.py
+++ b/patsy/categorical.py
@@ -45,11 +45,14 @@ from patsy.util import (SortAnythingKey,
                         pandas_Categorical_from_codes,
                         pandas_Categorical_categories,
                         pandas_Categorical_codes,
+                        have_xarray,
                         safe_issubdtype,
                         no_pickling, assert_no_pickling)
 
 if have_pandas:
     import pandas
+if have_xarray:
+    import xarray
 
 # Objects of this type will always be treated as categorical, with the
 # specified levels and contrast (if given).
@@ -188,6 +191,9 @@ class CategoricalSniffer(object):
             else:
                 # unbox and fall through
                 data = data.data
+        if have_xarray:
+            if isinstance(data, xarray.DataArray):
+                data = data.values
         if safe_is_pandas_categorical(data):
             # pandas.Categorical has its own NA detection, so don't try to
             # second-guess it.
@@ -323,6 +329,10 @@ def categorical_to_int(data, levels, NA_action, origin=None):
             raise PatsyError("mismatching levels: expected %r, got %r"
                              % (levels, tuple(data.levels)), origin)
         data = data.data
+
+    if have_xarray:
+        if isinstance(data, xarray.DataArray):
+            data = data.values
 
     data = _categorical_shape_fix(data)
 

--- a/patsy/highlevel.py
+++ b/patsy/highlevel.py
@@ -229,7 +229,10 @@ def dmatrix(formula_like, data={}, eval_env=0,
     :arg formula_like: An object that can be used to construct a design
       matrix. See below.
     :arg data: A dict-like object that can be used to look up variables
-      referenced in `formula_like`.
+      referenced in `formula_like`, including 1 or 2 dimensional
+      numpy record arrays, :class:`pandas.DataFrame` or
+      :class:`pandas.Series`, and :class:`xarray.DataArray` or
+      :class:`xarray.Dataset` objects.
     :arg eval_env: Either a :class:`EvalEnvironment` which will be used to
       look up any variables referenced in `formula_like` that cannot be
       found in `data`, or else a depth represented as an

--- a/patsy/util.py
+++ b/patsy/util.py
@@ -9,7 +9,7 @@ __all__ = ["atleast_2d_column_default", "uniqueify_list",
            "repr_pretty_delegate", "repr_pretty_impl",
            "SortAnythingKey", "safe_scalar_isnan", "safe_isnan",
            "iterable",
-           "have_pandas",
+           "have_pandas", "have_xarray",
            "have_pandas_categorical",
            "have_pandas_categorical_dtype",
            "pandas_Categorical_from_codes",
@@ -35,6 +35,13 @@ except ImportError:
     have_pandas = False
 else:
     have_pandas = True
+
+try:
+    import xarray
+except ImportError:
+    have_xarray = False
+else:
+    have_xarray = True
 
 # Pandas versions < 0.9.0 don't have Categorical
 # Can drop this guard whenever we drop support for such older versions of

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ changedir={envdir}
 commands=
   pip install scipy
   sh -c "[ \"x$NO_PANDAS\" = xTRUE ] || pip install pandas"
+  sh -c "[ \"x$NO_XARRAY\" = xTRUE ] || pip install xarray"
   coverage run --rcfile={toxinidir}/.coveragerc -p {envbindir}/nosetests --all-modules patsy {posargs:}
   env PATSY_AVOID_OPTIONAL_DEPENDENCIES=1 coverage run --rcfile={toxinidir}/.coveragerc -p {envbindir}/nosetests --all-modules patsy {posargs:}
   coverage combine --rcfile={toxinidir}/.coveragerc


### PR DESCRIPTION
Not sure if this is out of scope for the project, but this PR tries to smooth over the only issue I've came across so far when using Patsy with `xarray.Dataset` objects (in place of `pd.DataFrame`).

As a bit of background, xarray extends the idea of the data frame into an arbitrary number of dimensions, is now integrated into pandas, and is being considered as a replacement for the Panel capabilities in pandas. Xarray has two main data types -- `DataArray` and `Dataset` -- that are n-dimensional extensions of Panda's `Series` and `DataFrame` (see the [docs here](http://xarray.pydata.org/en/stable/why-xarray.html#core-data-structures)). I love using Patsy in my work with geospatial data, so such an integration would be great for me and might help down the road if Pandas deprecates Panel in favor of xarray objects.

To my surprise, feeding `xarray.Dataset` objects containing purely numeric data as the data into Patsy design matrix calls worked without any hangup. However, the integration breaks down when one tries to create a design matrix involving categorical data:

``` python
patsy.PatsyError: Error interpreting categorical data: all items must be hashable
```

For example, this error crops up in [`categorical.CategoricalSniffer:sniff`](https://github.com/pydata/patsy/blob/8b6c7121e7ec3f95da1fd9b9760945835abff8b3/patsy/categorical.py#L211). It seems the root of the issue is that the `__iter__` for an `xarray.DataArray` returns a single element still wrapped up in an `xarray.DataArray`, unlike when iterating over a `pd.Series` or `np.ndarray`.

I gave a go at a patch by defining `have_xarray` in `patsy/utils` and "unwrapping" data from its `xarray.DataArray` container before trying to perform any of the checks or conversions Patsy does with categorical data. I'm happy to iterate on design or implementation if you think it's worth integrating.

Thanks for your work!
