### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ building design matrices. Patsy brings the convenience of `R
    :target: https://coveralls.io/r/pydata/patsy?branch=master
 
 Documentation:
-  http://patsy.readthedocs.org/
+  https://patsy.readthedocs.io/
 
 Downloads:
   http://pypi.python.org/pypi/patsy/


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.