### PR TITLE
Adapt to new location of pandas is_categorical_dtype

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ matrix:
       env: PANDAS_VERSION_STR="=0.14.0 libgfortran=1.0"
     - python: 2.7
       env: PANDAS_VERSION_STR="=0.14.0 libgfortran=1.0"
+    # 0.18.0 has is_categorical_dtype in a different place than 0.19.0+
+    - python: 3.4
+      env: PANDAS_VERSION_STR="=0.18.0"
+    - python: 2.7
+      env: PANDAS_VERSION_STR="=0.18.0"
+
 # This disables sudo, but makes builds start much faster
 # See http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
 sudo: false

--- a/patsy/categorical.py
+++ b/patsy/categorical.py
@@ -134,7 +134,7 @@ def guess_categorical(data):
 
 def test_guess_categorical():
     if have_pandas_categorical:
-        c = pandas.Categorical.from_array([1, 2, 3])
+        c = pandas.Categorical([1, 2, 3])
         assert guess_categorical(c)
         if have_pandas_categorical_dtype:
             assert guess_categorical(pandas.Series(c))
@@ -242,7 +242,7 @@ def test_CategoricalSniffer():
             preps += [pandas.Series,
                       lambda x: C(pandas.Series(x))]
         for prep in preps:
-            t([], [prep(pandas.Categorical.from_array([1, 2, None]))],
+            t([], [prep(pandas.Categorical([1, 2, None]))],
               True, (1, 2))
             # check order preservation
             t([], [prep(pandas_Categorical_from_codes([1, 0], ["a", "b"]))],
@@ -250,7 +250,7 @@ def test_CategoricalSniffer():
             t([], [prep(pandas_Categorical_from_codes([1, 0], ["b", "a"]))],
               True, ("b", "a"))
             # check that if someone sticks a .contrast field onto our object
-            obj = prep(pandas.Categorical.from_array(["a", "b"]))
+            obj = prep(pandas.Categorical(["a", "b"]))
             obj.contrast = "CONTRAST"
             t([], [obj], True, ("a", "b"), "CONTRAST")
 

--- a/patsy/test_build.py
+++ b/patsy/test_build.py
@@ -580,7 +580,7 @@ def test_categorical():
     data_categ = {"a": C(["a2", "a1", "a2"])}
     datas = [data_strings, data_categ]
     if have_pandas_categorical:
-        data_pandas = {"a": pandas.Categorical.from_array(["a1", "a2", "a2"])}
+        data_pandas = {"a": pandas.Categorical(["a1", "a2", "a2"])}
         datas.append(data_pandas)
     def t(data1, data2):
         def iter_maker():

--- a/patsy/test_build.py
+++ b/patsy/test_build.py
@@ -429,7 +429,7 @@ def test_return_type_pandas():
                                       return_type="dataframe")
     assert isinstance(int_df, pandas.DataFrame)
     assert np.array_equal(int_df, [[1], [1], [1]])
-    assert int_df.index.equals([10, 20, 30])
+    assert int_df.index.equals(pandas.Index([10, 20, 30]))
 
     import patsy.build
     had_pandas = patsy.build.have_pandas
@@ -448,7 +448,7 @@ def test_return_type_pandas():
                                                    dtype=object)},
                                   NA_action="drop",
                                   return_type="dataframe")
-    assert x_df.index.equals([2])
+    assert x_df.index.equals(pandas.Index([2]))
 
 def test_data_mismatch():
     test_cases_twoway = [

--- a/patsy/test_highlevel.py
+++ b/patsy/test_highlevel.py
@@ -672,7 +672,7 @@ def test_dmatrix_NA_action():
         assert np.array_equal(mat, [[1, 2, 20],
                                     [1, 3, 30]])
         if return_type == "dataframe":
-            assert mat.index.equals([1, 2])
+            assert mat.index.equals(pandas.Index([1, 2]))
         assert_raises(PatsyError, dmatrix, "x + y", data=data,
                       return_type=return_type,
                       NA_action="raise")
@@ -681,8 +681,8 @@ def test_dmatrix_NA_action():
         assert np.array_equal(lmat, [[20], [30]])
         assert np.array_equal(rmat, [[1, 2], [1, 3]])
         if return_type == "dataframe":
-            assert lmat.index.equals([1, 2])
-            assert rmat.index.equals([1, 2])
+            assert lmat.index.equals(pandas.Index([1, 2]))
+            assert rmat.index.equals(pandas.Index([1, 2]))
         assert_raises(PatsyError,
                       dmatrices, "y ~ x", data=data, return_type=return_type,
                       NA_action="raise")
@@ -693,8 +693,8 @@ def test_dmatrix_NA_action():
         assert np.array_equal(lmat, [[20], [30], [40]])
         assert np.array_equal(rmat, [[1], [1], [1]])
         if return_type == "dataframe":
-            assert lmat.index.equals([1, 2, 3])
-            assert rmat.index.equals([1, 2, 3])
+            assert lmat.index.equals(pandas.Index([1, 2, 3]))
+            assert rmat.index.equals(pandas.Index([1, 2, 3]))
         assert_raises(PatsyError,
                       dmatrices, "y ~ 1", data=data, return_type=return_type,
                       NA_action="raise")

--- a/patsy/util.py
+++ b/patsy/util.py
@@ -664,7 +664,7 @@ def test_safe_is_pandas_categorical():
     assert not safe_is_pandas_categorical(np.arange(10))
 
     if have_pandas_categorical:
-        c_obj = pandas.Categorical.from_array(["a", "b"])
+        c_obj = pandas.Categorical(["a", "b"])
         assert safe_is_pandas_categorical(c_obj)
 
     if have_pandas_categorical_dtype:


### PR DESCRIPTION
I'm not sure what version this changed in, but originally the only way
to get is_categorical_dtype was as a private export from
pandas.core.common. Now that's deprecated, and you're supposed to get it
from pandas.api.type. We try both, to cover both periods.