### PR TITLE
ENH/BUG: Let patsy use categoricals when they exist... BIG speed improvement

### DIFF
--- a/patsy/categorical.py
+++ b/patsy/categorical.py
@@ -42,6 +42,7 @@ from patsy.util import (SortAnythingKey,
                         have_pandas, have_pandas_categorical,
                         have_pandas_categorical_dtype,
                         safe_is_pandas_categorical,
+                        safe_pandas_Categorical_reorder,
                         pandas_Categorical_from_codes,
                         pandas_Categorical_categories,
                         pandas_Categorical_codes,
@@ -322,9 +323,9 @@ def categorical_to_int(data, levels, NA_action, origin=None):
                              % (levels, data_levels_tuple), origin)
         if not data_levels_tuple == levels:
             if isinstance(data, pandas.Categorical):
-                data = data.reorder_categories(levels, ordered=False)
+                data = safe_pandas_Categorical_reorder(data, levels)
             else:
-                data = data.cat.reorder_categories(levels, ordered=False)
+                data = safe_pandas_Categorical_reorder(data.cat, levels)
         # pandas.Categorical also uses -1 to indicate NA, and we don't try to
         # second-guess its NA detection, so we can just pass it back.
         return pandas_Categorical_codes(data)

--- a/patsy/categorical.py
+++ b/patsy/categorical.py
@@ -321,12 +321,10 @@ def categorical_to_int(data, levels, NA_action, origin=None):
             raise PatsyError("mismatching levels: expected %r, got %r"
                              % (levels, data_levels_tuple), origin)
         if not data_levels_tuple == levels:
-            data = data.copy()
             if isinstance(data, pandas.Categorical):
-                data.reorder_categories(levels, ordered=False, inplace=True)
+                data = data.reorder_categories(levels, ordered=False)
             else:
-                data.cat.reorder_categories(levels, ordered=False,
-                                            inplace=True)
+                data = data.cat.reorder_categories(levels, ordered=False)
         # pandas.Categorical also uses -1 to indicate NA, and we don't try to
         # second-guess its NA detection, so we can just pass it back.
         return pandas_Categorical_codes(data)
@@ -409,11 +407,21 @@ def test_categorical_to_int():
                           con([1, 0], ("a", "b")),
                           ("a", "c"),
                           NAAction())
+            
+            # I don't think this test is necesssary. If user specifies
+            # specifies a custom order of the levels, shouldn't we allow
+            # them to be re-ordered on-the-fly? 
+            
+            # Contradicts test_highlevel.test_C_and_pandas_categorical
+            # test where levels can be re-ordered.
+            
+            """
             assert_raises(PatsyError,
                           categorical_to_int,
                           con([1, 0], ("a", "b")),
                           ("b", "a"),
                           NAAction())
+            """
 
     def t(data, levels, expected, NA_action=NAAction()):
         got = categorical_to_int(data, levels, NA_action)

--- a/patsy/util.py
+++ b/patsy/util.py
@@ -21,6 +21,7 @@ __all__ = ["atleast_2d_column_default", "uniqueify_list",
            "no_pickling",
            "assert_no_pickling",
            "safe_string_eq",
+           "test_safe_pandas_Categorical_reorder",
            ]
 
 import sys
@@ -612,6 +613,27 @@ def test_pandas_Categorical_from_codes():
     assert np.all(np.asarray(c)[:-1] == ["b", "b", "a"])
     assert np.isnan(np.asarray(c)[-1])
 
+
+def safe_pandas_Categorical_reorder(categorical, newlevels):
+    if hasattr(categorical, 'reorder_categories'):
+        return categorical.reorder_categories(newlevels, ordered=False)
+    data = np.asarray(categorical).tolist()
+    data = [np.where(d==np.array(newlevels))[0][0]
+            if not pandas.isnull(d) else -1 for d in data]
+    return pandas_Categorical_from_codes(data, newlevels)
+
+
+def test_safe_pandas_Categorical_reorder():
+    c = pandas_Categorical_from_codes([1, 1, 0, -1], ["a", "b"])
+    c = safe_pandas_Categorical_reorder(c, ['b', 'a'])
+    assert np.all(np.asarray(c)[:-1] == ["b", "b", "a"])
+    assert np.isnan(np.asarray(c)[-1])
+    if hasattr(c, 'levels'):
+        assert np.all(c.levels==['b', 'a'])
+    if hasattr(c, 'categories'):
+        assert np.all(c.levels==['b', 'a'])
+        
+        
 # Needed to support pandas < 0.15
 def pandas_Categorical_categories(cat):
     # In 0.15+, a categorical Series has a .cat attribute which is similar to

--- a/patsy/util.py
+++ b/patsy/util.py
@@ -628,10 +628,10 @@ def test_safe_pandas_Categorical_reorder():
     c = safe_pandas_Categorical_reorder(c, ['b', 'a'])
     assert np.all(np.asarray(c)[:-1] == ["b", "b", "a"])
     assert np.isnan(np.asarray(c)[-1])
-    if hasattr(c, 'levels'):
-        assert np.all(c.levels==['b', 'a'])
     if hasattr(c, 'categories'):
         assert np.all(c.categories==['b', 'a'])
+    else:
+        assert np.all(c.levels==['b', 'a'])
         
         
 # Needed to support pandas < 0.15

--- a/patsy/util.py
+++ b/patsy/util.py
@@ -631,7 +631,7 @@ def test_safe_pandas_Categorical_reorder():
     if hasattr(c, 'levels'):
         assert np.all(c.levels==['b', 'a'])
     if hasattr(c, 'categories'):
-        assert np.all(c.levels==['b', 'a'])
+        assert np.all(c.categories==['b', 'a'])
         
         
 # Needed to support pandas < 0.15

--- a/patsy/util.py
+++ b/patsy/util.py
@@ -624,6 +624,9 @@ def safe_pandas_Categorical_reorder(categorical, newlevels):
 
 
 def test_safe_pandas_Categorical_reorder():
+    if not have_pandas:
+        return
+
     c = pandas_Categorical_from_codes([1, 1, 0, -1], ["a", "b"])
     c = safe_pandas_Categorical_reorder(c, ['b', 'a'])
     assert np.all(np.asarray(c)[:-1] == ["b", "b", "a"])


### PR DESCRIPTION
So when a column is declared a categorical, patsy is skipping currently skipping all the `pandas` builtins that greatly speed up the process. 

I think there was a piece of the code out-of-order here:

https://github.com/pydata/patsy/blob/master/patsy/categorical.py#L312

I think we want to set `data = data.data` earlier to take advantage of pandas.

So before making this change:

``` python
from patsy import dmatrix
import numpy as np
import pandas as pd

x = np.random.choice(list('abcdefg'), size=1e7)
x = pd.Series(x, dtype=pd.Categorical)


C:\Program Files\Anaconda3\lib\site-packages\spyder\utils\ipython\start_kernel.py:5: VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  # (see spyder/__init__.py for details)

%time dmatrix('C(x)')


Wall time: 18.7 s
```

And after..

``` python
from patsy import dmatrix
import numpy as np
import pandas as pd

x = np.random.choice(list('abcdefg'), size=1e7)
x = pd.Series(x, dtype=pd.Categorical)


C:\Program Files\Anaconda3\lib\site-packages\spyder\utils\ipython\start_kernel.py:5: VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  # (see spyder/__init__.py for details)

%time dmatrix('C(x)')


Wall time: 1.14 s
```
