### PR TITLE
Support codings with "implicit intercept"

### DIFF
--- a/patsy/build.py
+++ b/patsy/build.py
@@ -18,6 +18,7 @@ from patsy.categorical import (guess_categorical,
 from patsy.util import (atleast_2d_column_default,
                         have_pandas, asarray_or_pandas,
                         safe_issubdtype)
+from patsy.desc import INTERCEPT
 from patsy.design_info import (DesignMatrix, DesignInfo,
                                FactorInfo, SubtermInfo)
 from patsy.redundancy import pick_contrasts_for_term
@@ -570,7 +571,8 @@ def test__examine_factor_types():
 
 def _make_subterm_infos(terms,
                         num_column_counts,
-                        cat_levels_contrasts):
+                        cat_levels_contrasts,
+                        implicit_intercept):
     # Sort each term into a bucket based on the set of numeric factors it
     # contains:
     term_buckets = OrderedDict()
@@ -601,9 +603,14 @@ def _make_subterm_infos(terms,
         used_subterms = set()
         for term in bucket_terms:
             subterm_infos = []
+            # If this bucket is empty, the unique noncategorical subterm is the
+            # intercept, so it should be skipped in pick_contrasts_for_term
+            # if implicit_intercept is True.
+            skip_noncategorical_subterm = implicit_intercept and not bucket
             factor_codings = pick_contrasts_for_term(term,
                                                      num_column_counts,
-                                                     used_subterms)
+                                                     used_subterms,
+                                                     skip_noncategorical_subterm)
             # Construct one SubtermInfo for each subterm
             for factor_coding in factor_codings:
                 subterm_factors = []
@@ -636,7 +643,7 @@ def _make_subterm_infos(terms,
     return term_to_subterm_infos
 
 def design_matrix_builders(termlists, data_iter_maker, eval_env,
-                           NA_action="drop"):
+                           NA_action="drop", implicit_intercept=False):
     """Construct several :class:`DesignInfo` objects from termlists.
 
     This is one of Patsy's fundamental functions. This function and
@@ -661,6 +668,10 @@ def design_matrix_builders(termlists, data_iter_maker, eval_env,
     :arg NA_action: An :class:`NAAction` object or string, used to determine
       what values count as 'missing' for purposes of determining the levels of
       categorical factors.
+    :arg implicit_intercept: A boolean value, default `False`.  When set to
+      `True`, the design matrix excludes the intercept, but its subterms are
+      chosen as if the intercept were included, even if it reduces the rank
+      of the resulting matrix.
     :returns: A list of :class:`DesignInfo` objects, one for each
       termlist passed in.
 
@@ -683,6 +694,10 @@ def design_matrix_builders(termlists, data_iter_maker, eval_env,
     if isinstance(NA_action, str):
         NA_action = NAAction(NA_action)
     all_factors = set()
+    for termlist in termlists:
+        if implicit_intercept and INTERCEPT in termlist:
+            raise PatsyError("An intercept should not be included explicitly"
+                             "if implicit_intercept is set to True")
     for termlist in termlists:
         for term in termlist:
             all_factors.update(term.factors)
@@ -718,7 +733,8 @@ def design_matrix_builders(termlists, data_iter_maker, eval_env,
     for termlist in termlists:
         term_to_subterm_infos = _make_subterm_infos(termlist,
                                                     num_column_counts,
-                                                    cat_levels_contrasts)
+                                                    cat_levels_contrasts,
+                                                    implicit_intercept)
         assert isinstance(term_to_subterm_infos, OrderedDict)
         assert frozenset(term_to_subterm_infos) == frozenset(termlist)
         this_design_factor_infos = {}

--- a/patsy/test_highlevel.py
+++ b/patsy/test_highlevel.py
@@ -660,6 +660,64 @@ def test_evalfactor_reraise():
     else:
         assert False
 
+def test_dmatrix_implicit_intercept():
+    data = balanced(a=2, b=2)
+    data["x"] = [1, 2, 3, 4]
+    data["y"] = [2, 3, 4, 5]
+
+    # Test that in a formula with one simple categorical term, one of
+    # the term's levels is excluded
+    mat = dmatrix("0 + a", data=data, implicit_intercept=True)
+    assert np.allclose(mat, [[0],
+                             [0],
+                             [1],
+                             [1]])
+
+    # In a more complicated formula with a categorical term,
+    # the encoding still excludes one categorical level
+    mat = dmatrix("0 + a:b + x", data=data, return_type="dataframe",
+                  implicit_intercept=True)
+    assert mat.shape[1] == 4
+    assert np.allclose(mat[['b[T.b2]', 'a[T.a2]:b[b1]', 'a[T.a2]:b[b2]', 'x']],
+                       [[0, 0, 0, 1],
+                        [1, 0, 0, 2],
+                        [0, 1, 0, 3],
+                        [1, 0, 1, 4]])
+
+    # A term with numerical and categorical factors should get a full-rank
+    # coding
+    mat = dmatrix("0 + a:x", data=data, return_type="dataframe",
+                  implicit_intercept=True)
+    assert mat.shape[1] == 2
+    assert np.allclose(mat[['a[a1]:x', 'a[a2]:x']],
+                       [[1, 0],
+                        [2, 0],
+                        [0, 3],
+                        [0, 4]])
+
+    # When using implicit_intercept, users should pass a formula that
+    # explicitly specifies no intercept (e.g. "0 + a" instead of "a").
+    # This tests that dmatrix raises an error if a user fails to do this.
+    assert_raises(PatsyError, dmatrix, "a", data=data, implicit_intercept=True)
+
+    # Test that in a formula with one simple categorical term, one of
+    # the term's levels is excluded
+    lmat, rmat = dmatrices("y ~ 0 + a", data=data, implicit_intercept=True)
+    assert np.allclose(lmat, [[2],
+                              [3],
+                              [4],
+                              [5]])
+    assert np.allclose(rmat, [[0],
+                              [0],
+                              [1],
+                              [1]])
+
+    # When using implicit_intercept, users should pass a formula that
+    # explicitly specifies no intercept (e.g. "0 + a" instead of "a").
+    # This tests that dmatrices raises an error if a user fails to do this.
+    assert_raises(PatsyError, dmatrices, "y ~ 1 + a", data=data,
+                  implicit_intercept=True)
+
 def test_dmatrix_NA_action():
     data = {"x": [1, 2, 3, np.nan], "y": [np.nan, 20, 30, 40]}
 


### PR DESCRIPTION
For some use cases, it would be nice to have patsy code a design matrix as if it were going to include an intercept (so e.g. it would exclude some categorical levels), but then not include the intercept.  See #80 for details.

This pull request adds an `implicit_intercept` parameter to some of the public functions (`dmatrix`, `dmatrices`, `incr_dbuilder`, `incr_dbuilders`, and `design_matrix_builders`).  When set to `True`, it codes the matrix as if an intercept were included but doesn't actually include the intercept.