### PR TITLE
MAINT: Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,10 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION numpy scipy coverage nose pip
+  - export PKGS="numpy scipy coverage nose pip"
+  - if [ "$PANDAS_VERSION_STR" != "NONE" ]; then export PKGS="${PKGS} pandas${PANDAS_VERSION_STR}"; fi
+  - conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION ${PKGS}
   - source activate testenv
-  - if [ "$PANDAS_VERSION_STR" != "NONE" ]; then conda install pandas${PANDAS_VERSION_STR}; fi
 install:
   - python setup.py sdist
   - pip install dist/*


### PR DESCRIPTION
Here's a way to fix travis. 

There's a conda dependency problem that can be easily solved by building the conda environment with only one `conda install`. 

`numpy.testing.util` is deprecated as well, so I did a `try/except` to use the newer one, if available. 

One concern is that numpy is deprecating `np.matrix`. 

```
======================================================================
ERROR: patsy.util.test_atleast_2d_column_default
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/miniconda/envs/testenv/lib/python3.6/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/travis/miniconda/envs/testenv/lib/python3.6/site-packages/patsy/util.py", line 176, in test_atleast_2d_column_default
    assert type(atleast_2d_column_default(np.matrix(1))) == np.ndarray
  File "/home/travis/miniconda/envs/testenv/lib/python3.6/site-packages/numpy/matrixlib/defmatrix.py", line 118, in __new__
    PendingDeprecationWarning, stacklevel=2)
PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
```

It might be time to deprecate it here too. 