### PR TITLE
ENH: add 3.7-dev to .travis.yml to test for compatibility with 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7-dev
 matrix:
   include:
     # 0.14.0 is the last version with the old categorical system


### PR DESCRIPTION
There might be some incompatibility which causes failing tests in 0.4.1 : https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=907335  so decided to check if current master compatible with 3.7