### PR TITLE
MAINT: Remove dead link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,6 @@ Code and bug tracker:
 Mailing list:
   * pydata@googlegroups.com
   * http://groups.google.com/group/pydata
-  * http://news.gmane.org/gmane.comp.python.pydata
 
 License:
   2-clause BSD, see LICENSE.txt for details.


### PR DESCRIPTION
This link in the README.rst goes nowhere. 