### PR TITLE
TST: Use pytest as the test runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,13 +49,16 @@ install:
 script:
   # We change directories to make sure that python won't find the copy
   # of patsy in the source directory.
-  - mkdir empty
-  - cd empty
-  - INSTALLDIR=$(python -c "import os; import patsy; print(os.path.dirname(patsy.__file__))")
+  # - mkdir empty
+  # - cd empty
+  # - INSTALLDIR=$(python -c "import os; import patsy; print(os.path.dirname(patsy.__file__))")
   - export PYTHONWARNINGS=default PATSY_FORCE_NO_WARNINGS=1
-  - pytest --cov=patsy --cov-config=../.coveragerc --cov-report= $INSTALLDIR
-  - coverage report --rcfile=../.coveragerc --show-missing
-  - python ../tools/check-API-refs.py
+  # - pytest --cov=patsy --cov-config=../.coveragerc --cov-report= $INSTALLDIR
+  - pytest --cov=patsy --cov-config=.coveragerc --cov-report= patsy
+  #- coverage report --rcfile=../.coveragerc --show-missing
+  - coverage report --rcfile=.coveragerc --show-missing
+  #- python ../tools/check-API-refs.py
+  - python tools/check-API-refs.py
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,20 @@
+sudo: false
 language: minimal
+
+env:
+  # Limit multithreading that causes execution time to blow up
+  - OMP_NUM_THREADS=1
+  - MKL_NUM_THREADS=1
+  - VML_NUM_THREADS=1
+
 matrix:
   include:
-    - env:
-      - PYTHON_VERSION=2.7
-    - env:
-      - PYTHON_VERSION=3.4
-    - env:
-      - PYTHON_VERSION=3.5
     - env:
       - PYTHON_VERSION=3.6
     - env:
       - PYTHON_VERSION=3.7
-    # 0.14.0 is the last version with the old categorical system
-    # libfortran=1.0 is needed to work around a bug in anaconda
-    # (https://github.com/pydata/patsy/pull/83#issuecomment-206895923)
     - env:
-      - PYTHON_VERSION=3.4
-      - PANDAS_VERSION_STR="=0.14.0 libgfortran=1.0"
-    - env:
-      - PYTHON_VERSION=2.7
-      - PANDAS_VERSION_STR="=0.14.0 libgfortran=1.0"
-    # 0.18.0 has is_categorical_dtype in a different place than 0.19.0+
-    - env:
-      - PYTHON_VERSION=3.4
-      - PANDAS_VERSION_STR="=0.18.0"
-    - env:
-      - PYTHON_VERSION=2.7
-      - PANDAS_VERSION_STR="=0.18.0"
-    # make sure it works without pandas
+      - PYTHON_VERSION=3.8
     - env:
       - PYTHON_VERSION=2.7
       - PANDAS_VERSION_STR="NONE"
@@ -40,10 +27,8 @@ matrix:
 
 # This disables sudo, but makes builds start much faster
 # See http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
-sudo: false
+
 before_install:
-  # Work around terrible pathological behaviour in OpenBLAS multithreading, that causes execution time to blow up from 3 minutes to 18 minutes, apparently in SVD on smallish matrices
-  - export OMP_NUM_THREADS=1
   # See: http://conda.pydata.org/docs/travis.html
   - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
@@ -52,13 +37,15 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - export PKGS="numpy scipy coverage nose pip"
+  - export PKGS="numpy scipy coverage nose pip pytest pytest-cov"
   - if [ "$PANDAS_VERSION_STR" != "NONE" ]; then export PKGS="${PKGS} pandas${PANDAS_VERSION_STR}"; fi
   - conda create -q -n testenv python=$PYTHON_VERSION ${PKGS}
   - source activate testenv
+
 install:
   - python setup.py sdist
   - pip install dist/*
+
 script:
   # We change directories to make sure that python won't find the copy
   # of patsy in the source directory.
@@ -66,15 +53,13 @@ script:
   - cd empty
   - INSTALLDIR=$(python -c "import os; import patsy; print(os.path.dirname(patsy.__file__))")
   - export PYTHONWARNINGS=default PATSY_FORCE_NO_WARNINGS=1
-  # The --exe is because python sometimes marks all installed modules
-  # as executable, so without --exe nosetests will just ignore
-  # everything. Baffling, but so it goes.
-  - coverage run --source=$INSTALLDIR --rcfile=../.coveragerc $(which nosetests) -vvv --nocapture --exe --failure-detail --all-modules $INSTALLDIR
+  - pytest --cov=patsy --cov-config=../.coveragerc --cov-report= $INSTALLDIR
   - coverage report --rcfile=../.coveragerc --show-missing
   - python ../tools/check-API-refs.py
+
 notifications:
   email:
     - njs@pobox.com
+
 after_success:
-  #- pip install coveralls && coveralls
   - pip install codecov && codecov

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ Dependencies:
 
 Optional dependencies:
   * nose: needed to run tests
+  * pytest: needed to run tests
   * scipy: needed for spline-related functions like ``bs``
 
 Install:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal=1
+
+[tool:pytest]
+python_files=*.py

--- a/tools/check-API-refs.py
+++ b/tools/check-API-refs.py
@@ -14,14 +14,15 @@ doc_re = re.compile(r"^\.\. (.*):: ([^\(]*)")
 
 def _documented(rst_path):
     documented = set()
-    for line in open(rst_path):
-        match = doc_re.match(line.rstrip())
-        if match:
-            directive = match.group(1)
-            symbol = match.group(2)
-            if directive not in ["module", "ipython"]:
-                documented.add(symbol)
-    return documented
+    with open(rst_path) as rst_file:
+        for line in rst_file:
+            match = doc_re.match(line.rstrip())
+            if match:
+                directive = match.group(1)
+                symbol = match.group(2)
+                if directive not in ["module", "ipython"]:
+                    documented.add(symbol)
+        return documented
 
 
 try:

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@ envlist = py26,py27,py31,py32,py33,py27-no-pandas,py32-no-pandas
 [testenv]
 deps=
   nose
+  pytest
+  pytest-cov
   coverage
   numpy
 # Display all warnings, and error out on any warnings attributed to
@@ -16,8 +18,8 @@ changedir={envdir}
 commands=
   pip install scipy
   sh -c "[ \"x$NO_PANDAS\" = xTRUE ] || pip install pandas"
-  coverage run --rcfile={toxinidir}/.coveragerc -p {envbindir}/nosetests --all-modules patsy {posargs:}
-  env PATSY_AVOID_OPTIONAL_DEPENDENCIES=1 coverage run --rcfile={toxinidir}/.coveragerc -p {envbindir}/nosetests --all-modules patsy {posargs:}
+  pytest --rcfile={toxinidir}/.coveragerc patsy {posargs:}
+  env PATSY_AVOID_OPTIONAL_DEPENDENCIES=1 pytest --rcfile={toxinidir}/.coveragerc patsy {posargs:}
   coverage combine --rcfile={toxinidir}/.coveragerc
   coverage report --rcfile={toxinidir}/.coveragerc
   coverage html --rcfile={toxinidir}/.coveragerc -d {toxworkdir}/coverage/{envname}


### PR DESCRIPTION
Switch to pytest
Remove testing of legacy Python versions < 3.6