### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/doc/expert-model-specification.rst
+++ b/doc/expert-model-specification.rst
@@ -95,7 +95,7 @@ things are.)
    dmatrix(desc, data)
 
 Notice that no intercept term is included. Implicit intercepts are a
-feature of the formula parser, not the underlying represention. If you
+feature of the formula parser, not the underlying representation. If you
 want an intercept, include the constant :const:`INTERCEPT` in your
 list of terms (which is just sugar for ``Term([])``).
 

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -166,7 +166,7 @@ standard representation, all this work happens *after* any
 transformations you perform as part of your formula. So, for example,
 if your data is in the form of numpy arrays, "+" will perform
 element-wise addition, but if it is in standard Python lists, it will
-perform concatentation:
+perform concatenation:
 
 .. ipython:: python
 

--- a/patsy/splines.py
+++ b/patsy/splines.py
@@ -41,7 +41,7 @@ def _eval_bspline_basis(x, knots, degree):
                                   "to handle them. (Patches accepted!)")
     # Thanks to Charles Harris for explaining splev. It's not well
     # documented, but basically it computes an arbitrary b-spline basis
-    # given knots and degree on some specificed points (or derivatives
+    # given knots and degree on some specified points (or derivatives
     # thereof, but we don't use that functionality), and then returns some
     # linear combination of these basis functions. To get out the basis
     # functions themselves, we use linear combinations like [1, 0, 0], [0,

--- a/patsy/state.py
+++ b/patsy/state.py
@@ -105,7 +105,7 @@ class Center(object):
     def transform(self, x):
         x = asarray_or_pandas(x)
         # This doesn't copy data unless our input is a DataFrame that has
-        # heterogenous types. And in that case we're going to be munging the
+        # heterogeneous types. And in that case we're going to be munging the
         # types anyway, so copying isn't a big deal.
         x_arr = np.asarray(x)
         if safe_issubdtype(x_arr.dtype, np.integer):

--- a/patsy/util.py
+++ b/patsy/util.py
@@ -480,7 +480,7 @@ def test_repr_pretty():
     assert printer.getvalue() == "MyClass('a', 1, foo='bar', asdf='asdf')"
 
 # In Python 3, objects of different types are not generally comparable, so a
-# list of heterogenous types cannot be sorted. This implements a Python 2
+# list of heterogeneous types cannot be sorted. This implements a Python 2
 # style comparison for arbitrary types. (It works on Python 2 too, but just
 # gives you the built-in ordering.) To understand why this is tricky, consider
 # this example:


### PR DESCRIPTION
There are small typos in:
- doc/expert-model-specification.rst
- doc/quickstart.rst
- patsy/splines.py
- patsy/state.py
- patsy/util.py

Fixes:
- Should read `heterogeneous` rather than `heterogenous`.
- Should read `specified` rather than `specificed`.
- Should read `representation` rather than `represention`.
- Should read `concatenation` rather than `concatentation`.

Closes #172