### PR TITLE
Add py27 and py39 to build matrix.

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
         pandas-presence: ['with_pandas', 'without_pandas']
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,10 @@ setup(
       "Programming Language :: Python :: 2",
       "Programming Language :: Python :: 2.7",
       "Programming Language :: Python :: 3",
-      "Programming Language :: Python :: 3.4",
-      "Programming Language :: Python :: 3.5",
+      "Programming Language :: Python :: 3.6",
+      "Programming Language :: Python :: 3.7",
+      "Programming Language :: Python :: 3.8",
+      "Programming Language :: Python :: 3.9",
       "Topic :: Scientific/Engineering",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38}-{with_pandas,without_pandas}
+envlist = {py27,py36,py37,py38,py39}-{with_pandas,without_pandas}
 
 [testenv]
 deps=


### PR DESCRIPTION
Until we formally deprecate python 2.7 let's keep it in the build matrix.