### PR TITLE
MAINT: Repalce row_stack with vstack

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "*"
+  pull_request:
+    branches:
+      - "*"
 
 jobs:
   build:

--- a/doc/stateful-transforms.rst
+++ b/doc/stateful-transforms.rst
@@ -102,7 +102,7 @@ just similar enough for you to miss the problem until it's too late.)
                    {"x": data["x"][2:]}]
    dinfo = incr_dbuilder("naive_center(x)", lambda: iter(data_chunked))
    # Broken!
-   np.row_stack([build_design_matrices([dinfo], chunk)[0]
+   np.vstack([build_design_matrices([dinfo], chunk)[0]
                  for chunk in data_chunked])
 
 But if we use the proper stateful transform, this just works:
@@ -111,7 +111,7 @@ But if we use the proper stateful transform, this just works:
 
    dinfo = incr_dbuilder("center(x)", lambda: iter(data_chunked))
    # Correct!
-   np.row_stack([build_design_matrices([dinfo], chunk)[0]
+   np.vstack([build_design_matrices([dinfo], chunk)[0]
                  for chunk in data_chunked])
 
 .. note::

--- a/patsy/constraint.py
+++ b/patsy/constraint.py
@@ -86,8 +86,8 @@ class LinearConstraint(object):
         for constraint in constraints:
             if constraint.variable_names != variable_names:
                 raise ValueError("variable names don't match")
-        coefs = np.row_stack([c.coefs for c in constraints])
-        constants = np.row_stack([c.constants for c in constraints])
+        coefs = np.vstack([c.coefs for c in constraints])
+        constants = np.vstack([c.constants for c in constraints])
         return cls(variable_names, coefs, constants)
 
 def test_LinearConstraint():

--- a/patsy/state.py
+++ b/patsy/state.py
@@ -59,7 +59,7 @@ def stateful_transform(class_):
 #         self._kwargs = kwargs
 #
 #     def memorize_finish(self):
-#         all_data = np.row_stack(self._data)
+#         all_data = np.vstack(self._data)
 #         args = self._args
 #         kwargs = self._kwargs
 #         del self._data

--- a/patsy/test_state.py
+++ b/patsy/test_state.py
@@ -90,7 +90,7 @@ def check_stateful(cls, accepts_multicolumn, input, output, *args, **kwargs):
         elif all_outputs[0].ndim == 1:
             all_output1 = np.concatenate(all_outputs)
         else:
-            all_output1 = np.row_stack(all_outputs)
+            all_output1 = np.vstack(all_outputs)
         assert all_output1.shape[0] == len(input)
         # output_obj_reshaped = np.asarray(output_obj).reshape(all_output1.shape)
         # assert np.allclose(all_output1, output_obj_reshaped)
@@ -101,11 +101,11 @@ def check_stateful(cls, accepts_multicolumn, input, output, *args, **kwargs):
             # handles both Series and DataFrames
             all_input = pandas.concat(input_obj)
         elif np.asarray(input_obj[0]).ndim == 1:
-            # Don't use row_stack, because that would turn this into a 1xn
+            # Don't use vstack, because that would turn this into a 1xn
             # matrix:
             all_input = np.concatenate(input_obj)
         else:
-            all_input = np.row_stack(input_obj)
+            all_input = np.vstack(input_obj)
         all_output2 = t.transform(all_input, *args, **kwargs)
         if have_pandas and isinstance(input_obj[0], pandas_type):
             assert np.array_equal(all_output2.index, pandas_index)


### PR DESCRIPTION
row_stack is official deprecated in NumPy 2, and will be dropped eventually.  Currently produces a warning