### PR TITLE
Avoid deprecated pandas `is_categorical_dtype` API

### DIFF
--- a/patsy/util.py
+++ b/patsy/util.py
@@ -41,28 +41,16 @@ else:
 # pandas.
 have_pandas_categorical = (have_pandas and hasattr(pandas, "Categorical"))
 if not have_pandas:
-    have_pandas_categorical_dtype = False
     _pandas_is_categorical_dtype = None
 else:
-    if hasattr(pandas, "api"):
-        # This is available starting in pandas v0.19.0
-        have_pandas_categorical_dtype = True
+    if hasattr(pandas, "CategoricalDtype"):  # pandas >= 0.25
+        _pandas_is_categorical_dtype = lambda x: isinstance(getattr(x, "dtype", x), pandas.CategoricalDtype)
+    elif hasattr(pandas, "api"):  # pandas >= 0.19
         _pandas_is_categorical_dtype = getattr(pandas.api.types, "is_categorical_dtype", None)
-        # pandas.api.types._pandas_is_categorical_dtype is deprecated in pandas v2.1.0
-        if _pandas_is_categorical_dtype is not None:
-            import warnings
-            with warnings.catch_warnings(record=True) as w:
-                _pandas_is_categorical_dtype(int)
-                if len(w) > 0 and issubclass(w[-1].category, FutureWarning):
-                    _pandas_is_categorical_dtype = None
-        else:
-            _pandas_is_categorical_dtype = lambda x: isinstance(x, pandas.CategoricalDType)
-    else:
-        # This is needed for pandas v0.18.0 and earlier
+    else:  # pandas <=0.18
         _pandas_is_categorical_dtype = getattr(pandas.core.common,
                                                "is_categorical_dtype", None)
-        have_pandas_categorical_dtype = (_pandas_is_categorical_dtype
-                                         is not None)
+have_pandas_categorical_dtype = _pandas_is_categorical_dtype is not None
 
 
 # Passes through Series and DataFrames, call np.asarray() on everything else


### PR DESCRIPTION
This patch side-steps the issues addressed by #198 and #199, but avoiding recently deprecated APIs.