### PR TITLE
Migrate to `setup-python` in GitHub Actions (and enable 3.13 tox builds).

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,14 +21,26 @@ jobs:
       PANDAS_PRESENCE: ${{ matrix.pandas-presence }}
     steps:
     - uses: actions/checkout@v2
-    - uses: gabrielfalcao/pyenv-action@v17
+    - name: Set up Python ${{ matrix.python-version }}
+      id: gha-python
+      uses: actions/setup-python@v4
       with:
-        default: "${{ matrix.python-version }}"
-    - name: Install Python ${{ matrix.python-version }}
+        python-version: ${{ matrix.python-version }}
+      continue-on-error: true
+    - name: Install PyEnv
+      if: ${{ steps.gha-python.outcome == 'failure' }}
       run: |
-          pyenv install "${{ matrix.python-version }}"
-          pyenv local "${{ matrix.python-version }}"
-          pyenv versions
+        curl https://pyenv.run | bash
+        PYENV_ROOT="$HOME/.pyenv"
+        echo "$PYENV_ROOT/bin" >> $GITHUB_PATH
+        echo "$PYENV_ROOT/shims" >> $GITHUB_PATH
+        echo "PYENV_ROOT=$PYENV_ROOT" >> $GITHUB_ENV
+    - name: Install Python ${{ matrix.python-version }} using PyEnv
+      if: ${{ steps.gha-python.outcome == 'failure' }}
+      run: |
+        pyenv install "${{ matrix.python-version }}"
+        pyenv local "${{ matrix.python-version }}"
+        pyenv versions
     - name: Install dependencies
       run: |
         pip install -U pip

--- a/patsy/eval.py
+++ b/patsy/eval.py
@@ -18,6 +18,7 @@ import inspect
 import tokenize
 import ast
 import numbers
+import pytest
 from patsy import PatsyError
 from patsy.util import PushbackAdapter, no_pickling, assert_no_pickling
 from patsy.tokens import pretty_untokenize, normalize_token_spacing, python_tokenize
@@ -423,6 +424,13 @@ def test_EvalEnvironment_subset():
     pytest.raises(NameError, subset_bc.eval, "a")
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 13),
+    reason=(
+        "`frame.f_locals` may return write-through proxies in Python 3.13+, "
+        "breaking direct comparison by ids."
+    ),
+)
 def test_EvalEnvironment_eq():
     # Two environments are eq only if they refer to exactly the same
     # global/local dicts

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38,py39,py310,py311,py312}-{with_pandas,without_pandas}
+envlist = {py36,py37,py38,py39,py310,py311,py312,py313}-{with_pandas,without_pandas}
 
 [gh-actions]
 python =
@@ -10,6 +10,7 @@ python =
   3.10: py310
   3.11: py311
   3.12: py312
+  3.13: py313
 
 [testenv]
 deps=


### PR DESCRIPTION
Where possible we will now use `setup-python`; only using `pyenv` where necessary for older Python versions.