### PR TITLE
BUG: Remove pytest import from top of module

### DIFF
--- a/patsy/eval.py
+++ b/patsy/eval.py
@@ -18,7 +18,6 @@ import inspect
 import tokenize
 import ast
 import numbers
-import pytest
 from patsy import PatsyError
 from patsy.util import PushbackAdapter, no_pickling, assert_no_pickling
 from patsy.tokens import pretty_untokenize, normalize_token_spacing, python_tokenize
@@ -424,14 +423,15 @@ def test_EvalEnvironment_subset():
     pytest.raises(NameError, subset_bc.eval, "a")
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 13),
-    reason=(
-        "`frame.f_locals` may return write-through proxies in Python 3.13+, "
-        "breaking direct comparison by ids."
-    ),
-)
 def test_EvalEnvironment_eq():
+    import pytest
+
+    if sys.version_info >= (3, 13):
+        pytest.skip(
+            "`frame.f_locals` may return write-through proxies in Python 3.13+, "
+            "breaking direct comparison by ids."
+        )
+
     # Two environments are eq only if they refer to exactly the same
     # global/local dicts
     env1 = EvalEnvironment.capture(0)

--- a/tox.ini
+++ b/tox.ini
@@ -32,3 +32,5 @@ commands=
   pytest -vv --cov=patsy --cov-config={toxinidir}/.coveragerc --cov-report=term-missing --cov-report=xml --cov-report=html:{toxworkdir}/coverage/{envname} {posargs:}
   env PATSY_AVOID_OPTIONAL_DEPENDENCIES=1 pytest -vv --cov=patsy --cov-config={toxinidir}/.coveragerc --cov-report=term-missing --cov-report=xml --cov-report=html:{toxworkdir}/coverage/{envname} {posargs:}
   python {toxinidir}/tools/check-API-refs.py
+  python -m pip uninstall pytest -y
+  python -c "import patsy; print(patsy.__version__)"


### PR DESCRIPTION
Move import to within the test function and change skip method

closes #215