### PR TITLE
fix: VarLookupDict __iter__ + DataFrame dtype compat (fixes #259, #232)

### DIFF
--- a/patsy/build.py
+++ b/patsy/build.py
@@ -80,7 +80,8 @@ def _eval_factor(factor_info, data, NA_action):
         if not safe_issubdtype(np.asarray(result).dtype, np.number):
             raise PatsyError(
                 "when evaluating numeric factor %s, "
-                "I got non-numeric data of type '%s'" % (factor.name(), np.asarray(result).dtype),
+                "I got non-numeric data of type '%s'"
+                % (factor.name(), np.asarray(result).dtype),
                 factor,
             )
         return result, NA_action.is_numerical_NA(result)

--- a/patsy/build.py
+++ b/patsy/build.py
@@ -80,7 +80,7 @@ def _eval_factor(factor_info, data, NA_action):
         if not safe_issubdtype(np.asarray(result).dtype, np.number):
             raise PatsyError(
                 "when evaluating numeric factor %s, "
-                "I got non-numeric data of type '%s'" % (factor.name(), result.dtype),
+                "I got non-numeric data of type '%s'" % (factor.name(), np.asarray(result).dtype),
                 factor,
             )
         return result, NA_action.is_numerical_NA(result)

--- a/patsy/eval.py
+++ b/patsy/eval.py
@@ -72,6 +72,20 @@ class VarLookupDict(object):
         except KeyError:
             return default
 
+    def __iter__(self):
+        seen = set()
+        for d in self._dicts:
+            for key in d:
+                if key not in seen:
+                    seen.add(key)
+                    yield key
+
+    def __len__(self):
+        return len(list(iter(self)))
+
+    def keys(self):
+        return list(iter(self))
+
     def __repr__(self):
         return "%s(%r)" % (self.__class__.__name__, self._dicts)
 


### PR DESCRIPTION
## Fixes #259 — VarLookupDict missing `__iter__`
Added `__iter__`, `__len__`, and `keys()` to `VarLookupDict` to prevent CPython crash during traceback formatting.

## Fixes #232 — DataFrame `.dtype` access in `_eval_factor`
Changed `result.dtype` to `np.asarray(result).dtype` so the error message works with both numpy arrays and pandas DataFrames.